### PR TITLE
Feature/45 add external link icon

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -26,7 +26,7 @@ jobs:
         if: github.event.action != 'closed'
         with:
             token: ${{secrets.GITHUB_TOKEN}}
-            mdbook-version: '0.4.52'
+            mdbook-version: 'latest'
             use-admonish: true
 
       - name: Build mdBook site


### PR DESCRIPTION
This simple css adds a little, opinionated "off-campus" or external resource indicator icon, like:


<img width="360" height="273" alt="image" src="https://github.com/user-attachments/assets/054009d1-bedf-44f4-872c-383e62bc8715" />


The opinionated part is whether this means "off this docs site" or "off campus," and I chose the latter: I would rather folks know they are going off-off-site and just trust the links within the documentation, to other Tamu documentation, or to Tamu tools (like the GitHub portal).

~I also slipped in another pinning of mdbook version from the PR that actually fixes it so that preview would be nice here.~ Preview references production site stylesheets via long relative path, and I did not seek to untangle that. So I removed this unrelated fix from _this PR_, and you can refer to my screenshot above instead.

Resolves #45 