### PR TITLE
Add multi-platform devcontainer with mdbook installation via Cargo

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,13 +1,13 @@
-FROM alpine:latest AS stage
-
-RUN wget https://github.com/rust-lang/mdBook/releases/download/v0.4.37/mdbook-v0.4.37-aarch64-unknown-linux-musl.tar.gz
-RUN tar -xvf mdbook-v0.4.37-aarch64-unknown-linux-musl.tar.gz
-
-RUN wget https://github.com/tommilligan/mdbook-admonish/releases/download/v1.15.0/mdbook-admonish-v1.15.0-x86_64-unknown-linux-musl.tar.gz
-RUN tar -xvf mdbook-admonish-v1.15.0-x86_64-unknown-linux-musl.tar.gz
-
 FROM alpine:latest
-COPY --from=stage mdbook /usr/local/bin/mdbook
-COPY --from=stage mdbook-admonish /usr/local/bin/mdbook-admonish
+
+ARG MDBOOK_VERSION=0.5.3
+ARG ADMONISH_VERSION=1.20.0
+
+RUN apk add cargo --no-cache
+RUN cargo install mdbook@${MDBOOK_VERSION}
+RUN cargo install mdbook-admonish@${ADMONISH_VERSION}
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+
 WORKDIR /project
 ENTRYPOINT ["mdbook"]


### PR DESCRIPTION
This pull request updates the `.devcontainer/Dockerfile` to simplify the installation process for `mdbook` and `mdbook-admonish`, and to use more recent versions of these tools. The changes replace manual binary downloads with installation via Cargo, making the Dockerfile easier to maintain and update.

Dependency installation improvements:

* Switched from downloading and extracting prebuilt binaries to installing `mdbook` and `mdbook-admonish` via Cargo, using version arguments for easier updates.
* Updated the default versions to `mdbook` 0.5.3 and `mdbook-admonish` 1.20.0.

Dockerfile simplification:

* Removed the multi-stage build, as binaries are now installed directly via Cargo, and set the `PATH` to include Cargo's bin directory.Use cargo (rust package manager) to install mdbook so it resolves the platform and all dependencies.