### PR TITLE
Quick pass at additional 404s, some new azure, some old aws

### DIFF
--- a/src/cloud/aws/migration.md
+++ b/src/cloud/aws/migration.md
@@ -36,8 +36,7 @@ If you are already managing your AWS resources via Terraform and wish to migrate
 - The overall pattern you will want to follow is to create new resources in your terraform code that are bound to the new, shared VPC (i.e. ALB and associated resources, subnet group for RDS, security groups, etc.) side by side with old version bound to the old VPC. Next, move the resource(s) that depends on these things to use the new resource. Lastly, delete the old resource(s) pointing to the old VPC.
 - You can't update security groups in Terraform if there are resources already depending on them. Instead, create new security groups, point old resources to them, then delete old security groups.
 - When creating security groups, wherever possible, don't rely on CIDR blocks if you are trying to limit access to one resource to another managaed resource. Instead, use `security_groups`. I.e. `security_groups   = [aws_security_group.<resource_name>.id]`. This will allow Amazon to use its knowledge of the resources represented by the other security group to limit access.
-- See this page for [details on referencing subnets with Terraform](./network.md#using-subnet-with-terraform)
-
+- See this page for [details on referencing subnets with Terraform](/cloud/aws/network.md#using-subnet-with-terraform)
 
 
 ### EC2 Instances
@@ -99,7 +98,7 @@ To move within the same region:
 > Details for migrating RDS to a different region: [Migrate Amazon Aurora and Amazon RDS to a new AWS region](https://aws.amazon.com/blogs/database/migrate-amazon-aurora-and-amazon-rds-to-a-new-aws-region/).
 
 > [!NOTE]
-> Details for moving an RDS instance out of an Availability Zone: [How do I move an Amazon RDS instance out of an Availability Zone?](https://repost.aws/knowledge-center/rds-move-availability-zone) Note that you will need to be sure that the AZ that the RDS is moved to is [one of the supported AZ's](./network.md#using-subnets)
+> Details for moving an RDS instance out of an Availability Zone: [How do I move an Amazon RDS instance out of an Availability Zone?](https://repost.aws/knowledge-center/rds-move-availability-zone) Note that you will need to be sure that the AZ that the RDS is moved to is [one of the supported AZ's](/cloud/aws/network.md#using-subnets)
 
 ### Redshift Clusters
 

--- a/src/cloud/aws/migration.md
+++ b/src/cloud/aws/migration.md
@@ -23,7 +23,7 @@ Before migrating any resources, you should complete the following steps:
    2. If your resource is currently connecting to a campus service, it will need to use a campus subnet.
       1. Email [aip@tamu.edu](mailto:aip@tamu.edu) to request a consultation before getting access to a campus subnet. 
    3. All other resources should use a private subnet.
-   4. More information on the network and subnets can be found [here](https://docs.cloud.tamu.edu/cloud/aws/networking.html#reference).
+   4. More information on the network and subnets can be found [here](./network.md#using-subnets).
 2. Copy any security groups in use by your resource to the new VPC.
    1. If you are only moving the resource to a new subnet within one of the TAMU shared VPCs, you can use the same security group.
    2. If you are having to move regions or VPCs, you will need to copy the security groups. See [copying security groups](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/working-with-security-groups.html#copy-security-group) for instructions.
@@ -36,7 +36,7 @@ If you are already managing your AWS resources via Terraform and wish to migrate
 - The overall pattern you will want to follow is to create new resources in your terraform code that are bound to the new, shared VPC (i.e. ALB and associated resources, subnet group for RDS, security groups, etc.) side by side with old version bound to the old VPC. Next, move the resource(s) that depends on these things to use the new resource. Lastly, delete the old resource(s) pointing to the old VPC.
 - You can't update security groups in Terraform if there are resources already depending on them. Instead, create new security groups, point old resources to them, then delete old security groups.
 - When creating security groups, wherever possible, don't rely on CIDR blocks if you are trying to limit access to one resource to another managaed resource. Instead, use `security_groups`. I.e. `security_groups   = [aws_security_group.<resource_name>.id]`. This will allow Amazon to use its knowledge of the resources represented by the other security group to limit access.
-- See this page for [details on referencing subnets with Terraform](https://docs.cloud.tamu.edu/cloud/aws/networking.html#using-subnets-with-terraform)
+- See this page for [details on referencing subnets with Terraform](./network.md#using-subnet-with-terraform)
 
 
 
@@ -99,7 +99,7 @@ To move within the same region:
 > Details for migrating RDS to a different region: [Migrate Amazon Aurora and Amazon RDS to a new AWS region](https://aws.amazon.com/blogs/database/migrate-amazon-aurora-and-amazon-rds-to-a-new-aws-region/).
 
 > [!NOTE]
-> Details for moving an RDS instance out of an Availability Zone: [How do I move an Amazon RDS instance out of an Availability Zone?](https://repost.aws/knowledge-center/rds-move-availability-zone) Note that you will need to be sure that the AZ that the RDS is moved to is [one of the supported AZ's](https://docs.cloud.tamu.edu/cloud/aws/networking.html#using-subnets)
+> Details for moving an RDS instance out of an Availability Zone: [How do I move an Amazon RDS instance out of an Availability Zone?](https://repost.aws/knowledge-center/rds-move-availability-zone) Note that you will need to be sure that the AZ that the RDS is moved to is [one of the supported AZ's](./network.md#using-subnets)
 
 ### Redshift Clusters
 

--- a/src/cloud/azure/network/services/connect_aks.md
+++ b/src/cloud/azure/network/services/connect_aks.md
@@ -12,7 +12,7 @@
 - NSGs on AKS subnets must permit the platform traffic AKS requires plus your application traffic from approved sources. Avoid blocking intra-cluster traffic between the node subnet and pod subnet.
 - For internet-facing application traffic, expose workloads through an **internal** ingress controller or internal load balancer service (`service.beta.kubernetes.io/azure-load-balancer-internal: "true"`) and front it with the shared hub-managed Azure Front Door via Private Link.
 - Container images must be pulled from a private Azure Container Registry with a Private Endpoint where possible. Public registry pulls will traverse the hub firewall and may be subject to filtering.
-- Administrative access (`kubectl`, `az aks command invoke`) must use private networking. Use Azure Bastion to a jump host in the VNet, the campus VPN, or `az aks command invoke` (which tunnels through the Azure control plane) — see [Access Methods](../access_methods.md).
+- Administrative access (`kubectl`, `az aks command invoke`) must use private networking. Use Azure Bastion to a jump host in the VNet, the campus VPN, or `az aks command invoke` (which tunnels through the Azure control plane) — see [Access Methods](/cloud/azure/network/access_methods.md).
 - The cluster identity must have appropriate RBAC on the spoke VNet, node subnet, pod subnet, and any private DNS zones used for the private API server. Use a user-assigned managed identity to keep these role assignments stable across cluster lifecycle operations.
 
 ## Implementation Pattern
@@ -95,7 +95,7 @@ AKS workloads must not be exposed via public load balancer services. Two support
 1. **Internal load balancer service / internal ingress controller** — Annotate `Service` resources of type `LoadBalancer` with `service.beta.kubernetes.io/azure-load-balancer-internal: "true"`, or deploy an ingress controller (NGINX, Traefik, AGIC, etc.) configured to use an internal LB. The resulting private IP is reachable from anywhere in the managed network and from the campus network.
 2. **AFD-fronted public ingress** — For workloads that must be reachable from the internet, the internal load balancer / ingress controller from pattern 1 becomes the AFD origin. Submit a Cloud Services request with the custom domain (if any), the internal hostname or IP, and any required WAF or routing rules. AFD will create a managed Private Endpoint to the load balancer, which you must approve.
 
-For more information, see [Access Methods](../access_methods.md).
+For more information, see [Access Methods](/cloud/azure/network/access_methods.md).
 
 ### Image Pulls and Azure Container Registry
 
@@ -111,7 +111,7 @@ The private API server is not reachable from the public internet. Approved admin
 - **Campus network / VPN** — Run `kubectl` and `az aks` commands from a workstation on the campus network or connected via Campus VPN, since the spoke VNet is reachable on its private IPs from those networks.
 - **`az aks command invoke`** — Tunnels commands through the Azure control plane to the cluster, requires no direct network reachability to the API server, and is useful for break-glass access. See [Use `command invoke` to access a private cluster](https://learn.microsoft.com/en-us/azure/aks/access-private-cluster).
 
-See [Access Methods](../access_methods.md) for the full list of approved administrative access patterns.
+See [Access Methods](/cloud/azure/network/access_methods.md) for the full list of approved administrative access patterns.
 
 ## Migrating
 

--- a/src/cloud/azure/network/services/connect_app_gateway.md
+++ b/src/cloud/azure/network/services/connect_app_gateway.md
@@ -13,7 +13,7 @@
 * AGW requires a dedicated subnet and should not share that subnet with unrelated workloads.
 * AGW subnet and backend subnets must have a User Defined Route (UDR) that sends outbound traffic to the hub-centralized firewall for inspection and logging.
 * NSGs should follow least privilege and allow only required inbound traffic from approved sources (for example, campus network ranges, VPN, or explicitly approved private peer ranges).
-* Administrative ports and management protocols must not be internet-exposed; use approved private access methods. See [Access Methods](../access_methods.md) for details.
+* Administrative ports and management protocols must not be internet-exposed; use approved private access methods. See [Access Methods](/cloud/azure/network/access_methods.md) for details.
 * For internet-facing application traffic, work with Cloud Services to configure hub-managed ingress (typically AFD for HTTP/S and firewall DNAT for non-HTTP/S workloads).
 
 Generally speaking, AGW behavior for backend pools, probes, listeners, and routing rules is configured as usual. The key TAMU-network differences are private placement, dedicated subnetting, and hub-managed internet ingress.
@@ -26,7 +26,7 @@ If you intend to publish your application to the internet, the recommended appro
 
 However, when using AFD-managed private endpoints, only AFD can access your application, and all traffic must go through AFD. Internal/Private traffic from other resources or networks will require a private endpoint in your spoke VNet.
 
-For more information, see [Access Methods](../access_methods.md).
+For more information, see [Access Methods](/cloud/azure/network/access_methods.md).
 
 ### Private Endpoint for Internal/Private Access
 
@@ -49,7 +49,7 @@ The steps below are generalized for new or existing AGW-backed services.
     1. Select or create a dedicated subnet for AGW.
     1. For Frontend IP Address Type, select Private (see [below](#creating-new-agw-and-encountering-error-public-frontend-ip-configuration-is-not-allowed)).
 1. Configure backend pools, listeners, health probes, and routing rules as required by your application.
-1. Open AGW/backend subnets > Route table and verify the hub firewall UDR is associated. See [Route Tables](../creating_subnets.md#route-tables) for details.
+1. Open AGW/backend subnets > Route table and verify the hub firewall UDR is associated. See [Route Tables](/cloud/azure/network/creating_subnets.md#route-tables) for details.
 1. Review subnet NSGs and verify only required ports and approved source ranges are allowed.
 
 ## Example Terraform Snippets

--- a/src/cloud/azure/network/services/connect_app_service.md
+++ b/src/cloud/azure/network/services/connect_app_service.md
@@ -8,7 +8,7 @@
 - App Service must be connected to the VNet via VNet Integration using a dedicated delegated subnet (`Microsoft.Web/serverFarms`) with a User Defined Route (UDR) directing outbound traffic to the hub firewall.
 - NSGs on the private endpoint subnet should follow least privilege and allow only required inbound traffic from approved sources (for example, campus network ranges, VPN, or the hub firewall).
 - For internet-facing application traffic, work with Cloud Services to configure hub-managed ingress via the shared Azure Front Door (AFD) instance.
-- Administrative access must not be internet-exposed. See [Access Methods](../access_methods.md) for details.
+- Administrative access must not be internet-exposed. See [Access Methods](/cloud/azure/network/access_methods.md) for details.
 - App Service Plan must be on a Basic SKU or higher to support both Private Endpoints and VNet Integration.
 
 ## Implementation Pattern
@@ -19,7 +19,7 @@ If you intend to publish your application to the internet, the recommended appro
 
 However, when using AFD-managed private endpoints, only AFD can access your application, and all traffic must go through AFD. Internal/Private traffic from other resources or networks will require a private endpoint in your spoke VNet.
 
-For more information, see [Access Methods](../access_methods.md).
+For more information, see [Access Methods](/cloud/azure/network/access_methods.md).
 
 ### Private Endpoint for Internal/Private Access
 

--- a/src/cloud/azure/network/services/connect_azure_functions.md
+++ b/src/cloud/azure/network/services/connect_azure_functions.md
@@ -113,7 +113,7 @@ The steps below are generalized for new or existing Function Apps.
 2. Under `Outbound traffic`, configure VNet Integration to the designated delegated subnet.
 3. Under `Inbound traffic`, configure a Private Endpoint targeting the private endpoint subnet.
 4. In Function App `Settings` > `Configuration` (or `Environment variables`), set `Public network access` to `Disabled`.
-5. Open the target subnet(s) > `Route table` and verify the hub firewall UDR is associated. See [Route Tables](/cloud/azure/network/creating_subnets.md#route-tables) for details.
+5. Open the target subnet(s) > `Route table` and verify the hub firewall UDR is associated. See [Route Tables](../creating_subnets.md#route-tables) for details.
 6. Review NSGs on the private endpoint subnet and verify only required ports and approved source ranges are allowed.
 
 ## Migrating

--- a/src/cloud/azure/network/services/connect_azure_functions.md
+++ b/src/cloud/azure/network/services/connect_azure_functions.md
@@ -8,7 +8,7 @@
 - HTTP triggers with `function`-level authorization may be directly internet-accessible, as the function key provides authentication. Public network access may be enabled for this case.
 - HTTP triggers with `admin`-level authorization must not be directly exposed to the internet under any circumstances.
 - NSGs should follow least privilege and allow only required inbound traffic from approved sources (for example, campus network ranges, VPN, or the hub firewall).
-- Administrative access must not be internet-exposed. See [Access Methods](../access_methods.md) for details.
+- Administrative access must not be internet-exposed. See [Access Methods](/cloud/azure/network/access_methods.md) for details.
 - Function App Plan must be on a Flex Consumption, Premium, or Dedicated (App Service Plan) SKU to support both Private Endpoints and VNet Integration. Consumption plan does not support VNet Integration.
 
 With the exception of anonymous HTTP triggers, your Function App triggers, bindings, deployment workflow, and runtime settings are configured as usual. The key TAMU-network differences are private inbound access and VNet-integrated outbound routing.
@@ -21,7 +21,7 @@ If you intend to publish your Function App to the internet, the recommended appr
 
 However, when using AFD-managed private endpoints, only AFD can access your application, and all traffic must go through AFD. Internal/Private traffic from other resources or networks will require a private endpoint in your spoke VNet.
 
-For more information, see [Access Methods](../access_methods.md).
+For more information, see [Access Methods](/cloud/azure/network/access_methods.md).
 
 ### Private Endpoint for Internal/Private Access
 
@@ -103,7 +103,7 @@ With public network access disabled, functions must be invoked and monitored thr
   ```
 
 - **Azure Portal "Test/Run" tab**: The Portal's built-in test tab works when your browser is on the campus network or VPN, since the request is proxied through the Portal to the private endpoint.
-- **Deployment from CI/CD**: Deployments via GitHub Actions or Azure DevOps pipelines do not require public access to the Function App; use the [Azure Functions GitHub Action](https://github.com/Azure/functions-action) or `az functionapp deployment` CLI commands. If the pipeline needs to reach resources inside the VNet (e.g. a private storage account), configure GitHub Actions private networking per the [CI/CD Access](../access_methods.md#cicd-access) guidance.
+- **Deployment from CI/CD**: Deployments via GitHub Actions or Azure DevOps pipelines do not require public access to the Function App; use the [Azure Functions GitHub Action](https://github.com/Azure/functions-action) or `az functionapp deployment` CLI commands. If the pipeline needs to reach resources inside the VNet (e.g. a private storage account), configure GitHub Actions private networking per the [CI/CD Access](/cloud/azure/network/access_methods.md#cicd-access) guidance.
 
 ## Steps in Azure Portal
 
@@ -113,7 +113,8 @@ The steps below are generalized for new or existing Function Apps.
 2. Under `Outbound traffic`, configure VNet Integration to the designated delegated subnet.
 3. Under `Inbound traffic`, configure a Private Endpoint targeting the private endpoint subnet.
 4. In Function App `Settings` > `Configuration` (or `Environment variables`), set `Public network access` to `Disabled`.
-5. Open the target subnet(s) > `Route table` and verify the hub firewall UDR is associated. See [Route Tables](../creating_subnets.md#route-tables) for details.
+5. Open the target subnet(s) > `Route table` and verify the hub firewall UDR is associated. See [Route Tables](/cloud/azure/network/creating_subnets.md#route-tables) for details.
+/cloud/aws/network.html#using-subnets
 6. Review NSGs on the private endpoint subnet and verify only required ports and approved source ranges are allowed.
 
 ## Migrating

--- a/src/cloud/azure/network/services/connect_container_app.md
+++ b/src/cloud/azure/network/services/connect_container_app.md
@@ -10,7 +10,7 @@
 - For inbound private access from within the managed network, use a Private Endpoint targeting the managed environment, or rely on the environment's internal load balancer IP if Private Endpoint is not required.
 - For internet-facing application traffic, work with Cloud Services to configure hub-managed ingress via the shared Azure Front Door (AFD) instance using a Private Endpoint to the Container Apps environment.
 - Container images should be pulled from a private Azure Container Registry with a Private Endpoint where possible.
-- Administrative access (console, log streaming) traverses the Azure control plane and does not require public network exposure on the environment itself. See [Access Methods](../access_methods.md) for details.
+- Administrative access (console, log streaming) traverses the Azure control plane and does not require public network exposure on the environment itself. See [Access Methods](/cloud/azure/network/access_methods.md) for details.
 
 ## Implementation Pattern
 
@@ -20,7 +20,7 @@ If you intend to publish your container app to the internet, the recommended app
 
 When using AFD-managed private endpoints, only AFD can access your environment over that private endpoint, and internet-facing traffic must go through AFD. Internal/private traffic from other resources or networks will continue to use the environment's internal load balancer IP or a separately provisioned Private Endpoint.
 
-For more information, see [Access Methods](../access_methods.md).
+For more information, see [Access Methods](/cloud/azure/network/access_methods.md).
 
 ### Internal Container Apps Environment with Private Endpoint
 

--- a/src/cloud/azure/network/services/connect_container_instances.md
+++ b/src/cloud/azure/network/services/connect_container_instances.md
@@ -8,7 +8,7 @@
 - NSGs on the container group subnet should follow least privilege and allow only required inbound traffic from approved sources (for example, campus network ranges, VPN, internal load balancers, or other spoke resources).
 - Container images should be pulled from a private registry (such as Azure Container Registry with a Private Endpoint) rather than public registries where possible. Outbound pulls from public registries will traverse the hub firewall and may be subject to filtering.
 - For internet-facing application traffic, work with Cloud Services to configure hub-managed ingress via the shared Azure Front Door (AFD) instance, fronted by an internal Load Balancer or Application Gateway in your spoke VNet that targets the container group's private IP.
-- Administrative access (e.g. `az container exec`) traverses the Azure control plane and does not require public network exposure on the container group itself. See [Access Methods](../access_methods.md) for details.
+- Administrative access (e.g. `az container exec`) traverses the Azure control plane and does not require public network exposure on the container group itself. See [Access Methods](/cloud/azure/network/access_methods.md) for details.
 - Container groups must use a SKU and OS type that supports VNet integration. Confirm support at [Virtual network scenarios for ACI](https://learn.microsoft.com/en-us/azure/container-instances/container-instances-virtual-network-concepts).
 
 ## Implementation Pattern
@@ -35,7 +35,7 @@ ACI does not natively support Azure Front Door Private Link as an origin. To pub
 1. Deploy an internal-only Application Gateway or internal Load Balancer in your spoke VNet that targets the private IP(s) of your container group(s).
 2. Submit a Cloud Services request to configure AFD with the App Gateway / Load Balancer as the origin via Private Link.
 
-For more information, see [Access Methods](../access_methods.md).
+For more information, see [Access Methods](/cloud/azure/network/access_methods.md).
 
 ## Migrating
 

--- a/src/cloud/azure/network/services/connect_load_balancer.md
+++ b/src/cloud/azure/network/services/connect_load_balancer.md
@@ -6,7 +6,7 @@
 - Load balancer frontends must only be private/internal.
 - The subnet selected for the load balancer frontend must have a User Defined Route (UDR) in order to be accessible from outside the VNet.
 - Security groups should follow least privilege and allow only required inbound traffic from approved sources (for example, campus network ranges, VPN, or explicitly approved private peer ranges).
-- Administrative ports and management protocols won't be internet-exposed if requested. See [Access Methods](../access_methods.md) for details.
+- Administrative ports and management protocols won't be internet-exposed if requested. See [Access Methods](/cloud/azure/network/access_methods.md) for details.
 - For internet-facing application traffic, work with Cloud Services to configure hub-managed ingress (AFD for HTTP/S or firewall DNAT for non-HTTP/S workloads).
 - Load Balancers are regional and cannot be migrated across regions.
 
@@ -16,7 +16,7 @@
 
 If your load balanced application is a web or other HTTP/S application and you intend to publish the application behind your load balancer to the internet, the recommended approach is to do so through the hub-managed Azure Front Door (AFD). Using this method, a private endpoint for inbound access is created and managed by AFD, and do you do not have to create or manage private DNS records or private endpoints yourself.
 
-For more information, see [Access Methods](../access_methods.md).
+For more information, see [Access Methods](/cloud/azure/network/access_methods.md).
 
 ### Private Endpoint for Internal/Private Access
 

--- a/src/cloud/azure/network/services/connect_vm.md
+++ b/src/cloud/azure/network/services/connect_vm.md
@@ -7,7 +7,7 @@
 - VM subnet must have a User Defined Route (UDR) that sends outbound traffic to the hub-centralized firewall for inspection and logging.
 - NSGs should follow least privilege and allow only required inbound traffic from approved sources (for example, campus network ranges, VPN, or explicitly approved private peer ranges).
 - If the VM hosts a workload that must be reachable from the internet, request Cloud Services configuration of hub firewall DNAT rules and any required DNS updates.
-- Administrative protocols (RDP, SSH, WinRM, etc.) must not be published to the internet; use private access methods from trusted networks. See [Access Methods](../access_methods.md) for details.
+- Administrative protocols (RDP, SSH, WinRM, etc.) must not be published to the internet; use private access methods from trusted networks. See [Access Methods](/cloud/azure/network/access_methods.md) for details.
 
 ## Implementation Pattern
 
@@ -30,7 +30,7 @@ The steps below are generalized for a new or existing VM.
    - `Associate public IP address` should be unchecked.
 1. Open the NSG on the NIC/subnet (<em>ex. NIC Overview > Properties: Click the NSG name under `Network security group`</em>) > `Inbound security rules`, and verify only approved source ranges and required ports are allowed.
 1. Open the attached NIC -> `IP configurations` and verify there is no associated Public IP.
-1. Open the target subnet -> `Route table` and verify hub FW UDR (see [Route Tables](../creating_subnets.md#route-tables) in **Creating Subnets** for details) is associated.
+1. Open the target subnet -> `Route table` and verify hub FW UDR (see [Route Tables](/cloud/azure/network/creating_subnets.md#route-tables) in **Creating Subnets** for details) is associated.
 
 ## Example Terraform Snippets
 

--- a/src/cloud/azure/network/services/connect_vm.md
+++ b/src/cloud/azure/network/services/connect_vm.md
@@ -30,7 +30,7 @@ The steps below are generalized for a new or existing VM.
    - `Associate public IP address` should be unchecked.
 1. Open the NSG on the NIC/subnet (<em>ex. NIC Overview > Properties: Click the NSG name under `Network security group`</em>) > `Inbound security rules`, and verify only approved source ranges and required ports are allowed.
 1. Open the attached NIC -> `IP configurations` and verify there is no associated Public IP.
-1. Open the target subnet -> `Route table` and verify hub FW UDR (see [Route Tables](/cloud/azure/network/creating_subnets.md#route-tables) in **Creating Subnets** for details) is associated.
+1. Open the target subnet -> `Route table` and verify hub FW UDR (see [Route Tables](../creating_subnets.md#route-tables) in **Creating Subnets** for details) is associated.
 
 ## Example Terraform Snippets
 

--- a/src/cloud/azure/network/services/use_bastion.md
+++ b/src/cloud/azure/network/services/use_bastion.md
@@ -7,7 +7,7 @@
 - NSGs on VM subnets should permit inbound RDP (3389) and/or SSH (22) traffic from the hub Bastion subnet (`AzureBastionSubnet`) address range for administrative access via Azure Bastion.
 - The shared Bastion is available to all spokes peered to the hub. Because spokes are peered to the hub VNet, the hub Bastion automatically appears as a connection option in the Azure portal when connecting to any VM in a peered spoke — no additional configuration is required by the customer.
 - Bastion access is governed by Azure RBAC. Users must have at least `Reader` on the VM, the VM's NIC, and the Bastion resource to initiate a session. Request access through Cloud Services if your account does not see the hub Bastion as an option.
-- See [Access Methods](../access_methods.md) for the full list of approved administrative access patterns.
+- See [Access Methods](/cloud/azure/network/access_methods.md) for the full list of approved administrative access patterns.
 
 ## Implementation Pattern
 


### PR DESCRIPTION
Locally, `mdbook` renders relative up-parent links like `../access_methods.md` as expected, but in deployment (and PR Preview) they break 🤷 

This PR replaces all Access Methods linked text and similar with rendered-site-root paths. mdbook is still happy to link to the _rendered_ .html, so I kept the .md file ending in the link.

**Caution:** The rendered links in this PR preview will link relative to production/live docs.cloud site root -- so don't let that fool you when clicking around!